### PR TITLE
Increase maximum skinned node and vertex count

### DIFF
--- a/src/dffimp.h
+++ b/src/dffimp.h
@@ -134,7 +134,7 @@ private:
 
 	INode *rootnode;
 
-	INode *skinNodes[5];
+	INode *skinNodes[256];
 	int numSkins;
 
 public:

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -537,7 +537,7 @@ DFFExport::writeDFF(const TCHAR *filename)
 		this->maxNodes = countNodes(rootnode);
 		//lprintf("number of nodes: %d\n", this->maxNodes);
 		this->nodearray = new RWNode[this->maxNodes];
-		this->nextId = 65535;
+		this->nextId = 2000;
 		this->inHierarchy = 1;
 	}
 

--- a/src/export.cpp
+++ b/src/export.cpp
@@ -537,7 +537,7 @@ DFFExport::writeDFF(const TCHAR *filename)
 		this->maxNodes = countNodes(rootnode);
 		//lprintf("number of nodes: %d\n", this->maxNodes);
 		this->nodearray = new RWNode[this->maxNodes];
-		this->nextId = 2000;
+		this->nextId = 65535;
 		this->inHierarchy = 1;
 	}
 


### PR DESCRIPTION
Those limits were not engine limitations and this fixes a few things for Shadow the Hedgehog and Sonic Heroes. While I don't know if they were applied in order to deal with issues in other games, upping these limits helps significantly for modding these two games.  