### PR TITLE
2023 x64 Support

### DIFF
--- a/README_release.txt
+++ b/README_release.txt
@@ -1,9 +1,9 @@
-DFF Import and Exporter 3.3 for 3ds max
+DFF Import and Exporter 3.4 for 3ds max
 =======================================
 
 Compatibility
 ==============
- Works with 3ds max 2009, 2010, 2011, 2012, 2014, 2015, 2016, 2017, 2018, 2020, 2021, 2022 64 bit and 2009, 2010, 2011, 2012 32 bit
+ Works with 3ds max 2009, 2010, 2011, 2012, 2014, 2015, 2016, 2017, 2018, 2020, 2021, 2022, 2023 64 bit and 2009, 2010, 2011, 2012 32 bit
 
 Installation
 ============

--- a/premake5.lua
+++ b/premake5.lua
@@ -117,3 +117,7 @@ project "rwio2021"
 project "rwio2022"
 	maxsdk = "C:/Users/aap/src/maxsdk/3ds Max 2022 SDK/maxsdk/"
 	maxplugin2(maxsdk)
+
+project "rwio2023"
+	maxsdk = "C:/Users/aap/src/maxsdk/3ds Max 2023 SDK/maxsdk/"
+	maxplugin2(maxsdk)


### PR DESCRIPTION
Adds entry for 2023 x64.
Built, tested, and validated with Shadow The Hedgehog DFF files
No changes needed besides adding a target

Changed README_release to current version (3.4) and added 2023 to supported list.